### PR TITLE
[debug] Remove "unprintable char 0" in debug messages

### DIFF
--- a/terminal.cpp
+++ b/terminal.cpp
@@ -350,7 +350,7 @@ void Terminal::insertInBuffer(const QString& chars)
                     insertAtCursor(ch, !iReplaceMode);
                 else if (ch.toLatin1()==ch_ESC)
                     escape=0;
-                else
+                else if (ch.toLatin1() != 0)
                     qDebug() << "unprintable char" << int(ch.toLatin1());
             }
         }


### PR DESCRIPTION
Avoid spamming the log when an application prints NUL bytes into
its output (like e.g. pkcon does sometimes).
