### PR TITLE
[behavior] Change default behavior to be more user-friendly

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -215,15 +215,15 @@ void defaultSettings(QSettings* settings)
     if(!settings->contains("ui/allowSwipe"))
         settings->setValue("ui/allowSwipe", "auto");   // "true", "false", "auto"
     if(!settings->contains("ui/keyboardFadeOutDelay"))
-        settings->setValue("ui/keyboardFadeOutDelay", 2500);
+        settings->setValue("ui/keyboardFadeOutDelay", 4000);
     if(!settings->contains("ui/showExtraLinesFromCursor"))
         settings->setValue("ui/showExtraLinesFromCursor", 1);
     if(!settings->contains("ui/vkbShowMethod"))
-        settings->setValue("ui/vkbShowMethod", "fade");  // "fade", "move", "off"
+        settings->setValue("ui/vkbShowMethod", "move");  // "fade", "move", "off"
     if(!settings->contains("ui/keyPressFeedback"))
         settings->setValue("ui/keyPressFeedback", true);
     if(!settings->contains("ui/dragMode"))
-        settings->setValue("ui/dragMode", "gestures");  // "gestures, "scroll", "select" ("off" would also be ok)
+        settings->setValue("ui/dragMode", "scroll");  // "gestures, "scroll", "select" ("off" would also be ok)
 
     if(!settings->contains("state/showWelcomeScreen"))
         settings->setValue("state/showWelcomeScreen", true);


### PR DESCRIPTION
Change some defaults to make it easier for first-time user to use the Terminal app, and avoid errors due to gestures. Also, change the default vkb mode to move, as the "fade" behavior is kind of unusual, and more for advanced users.

These changes are in line with commit 118039c111 from the silica branch.
