### PR TITLE
Fix pasting from SailfishOS clipboard to fingerterm.

### DIFF
--- a/terminal.cpp
+++ b/terminal.cpp
@@ -1144,17 +1144,10 @@ void Terminal::pasteFromClipboard()
 {
     QClipboard *cb = QGuiApplication::clipboard();
 
-    //mimeData() could be null when the clipboard QPA plugin of the platform doesn't support QClipboard::Clipboard, or
-    //the plugin is bugged.
-    //In those cases, disable clipboard features.
-    if(!cb->mimeData())
-        qDebug() << "FIXME: QClipboard::mimeData() returned NULL, the clipboard functionality will not be used";
-    else {
-        if(cb->mimeData()->hasText() && !cb->mimeData()->text().isEmpty()) {
-            if(iPtyIFace) {
-                resetBackBufferScrollPos();
-                iPtyIFace->writeTerm(cb->mimeData()->text());
-            }
+    if(cb->text().length() > 0) {
+        if(iPtyIFace) {
+            resetBackBufferScrollPos();
+            iPtyIFace->writeTerm(cb->text());
         }
     }
 }
@@ -1310,31 +1303,31 @@ void Terminal::copySelectionToClipboard()
                 text += line.trimmed() + "\n";
             }
         }
-
-        // main buffer
-        lineFrom = selection().top()-1-iBackBufferScrollPos;
-        lineTo = selection().bottom()-1-iBackBufferScrollPos;
-        for (int i=lineFrom; i<=lineTo; i++) {
-            if (i >= 0 && i < buffer().size()) {
-                line.clear();
-                int start = 0;
-                int end = buffer()[i].size()-1;
-                if (i==lineFrom)
-                    start = selection().left()-1;
-                if (i==lineTo)
-                    end = selection().right()-1;
-                for (int j=start; j<=end; j++) {
-                    if (j >= 0 && j < buffer()[i].size() && buffer()[i][j].c.isPrint())
-                        line += buffer()[i][j].c;
-                }
-                text += line.trimmed() + "\n";
-            }
-        }
-
-        //qDebug() << text.trimmed();
-
-        cb->setText(text.trimmed());
     }
+
+    // main buffer
+    int lineFrom = selection().top()-1-iBackBufferScrollPos;
+    int lineTo = selection().bottom()-1-iBackBufferScrollPos;
+    for (int i=lineFrom; i<=lineTo; i++) {
+        if (i >= 0 && i < buffer().size()) {
+            line.clear();
+            int start = 0;
+            int end = buffer()[i].size()-1;
+            if (i==lineFrom)
+                start = selection().left()-1;
+            if (i==lineTo)
+                end = selection().right()-1;
+            for (int j=start; j<=end; j++) {
+                if (j >= 0 && j < buffer()[i].size() && buffer()[i][j].c.isPrint())
+                    line += buffer()[i][j].c;
+            }
+            text += line.trimmed() + "\n";
+        }
+    }
+
+    //qDebug() << text.trimmed();
+
+    cb->setText(text.trimmed());
 }
 
 void Terminal::adjustSelectionPosition(int lines)

--- a/util.cpp
+++ b/util.cpp
@@ -379,19 +379,10 @@ bool Util::terminalHasSelection()
 
 bool Util::canPaste()
 {
-
     QClipboard *cb = QGuiApplication::clipboard();
 
-    //mimeData() could be null when the clipboard QPA plugin of the platform doesn't support QClipboard::Clipboard, or
-    //the plugin is bugged.
-    //In those cases, disable clipboard features.
-    if(!cb->mimeData()) {
-        qDebug() << "FIXME: QClipboard::mimeData() returned NULL, the clipboard functionality will not be used";
-        return false;
-    }
-    else {
-        if(cb->mimeData()->hasText() && !cb->mimeData()->text().isEmpty())
-            return true;
+    if(cb->text().length() > 0) {
+        return true;
     }
 
     return false;


### PR DESCRIPTION
Commit 90734807 broke the internal copy/paste in Fingerterm under SailfishOS, and the external (to/from other Sailfish apps) copying has not worked ever.

This patch fixes the internal copy/paste, and makes copying form Sailfish clipboard to Fingerterm possible.

The other direction still does not work, i.e. fingerterm clipboard contents are not transmitted to other SailfishOS apps.
