### PR TITLE
[spec] Inject RPM version number to version.h (Fixes #30)

### DIFF
--- a/rpm/fingerterm.spec
+++ b/rpm/fingerterm.spec
@@ -34,6 +34,8 @@ Provides: meego-terminal > 0.2.2
 %build
 sed -i 's,/opt/fingerterm/,/usr/,' fingerterm.pro
 qmake -qt=5 MEEGO_EDITION=nemo
+# Inject version number from RPM into source
+sed -i -e 's/PROGRAM_VERSION="[^"]*"/PROGRAM_VERSION="%{version}"/g' version.h
 make %{?_smp_mflags}
 
 


### PR DESCRIPTION
Backported fix from silica branch: https://github.com/nemomobile/fingerterm/commit/68e48dfd8c5cdd5d5e7e74e7ad135994cbcd4088