### PR TITLE
[util] Improve scrolling on high-DPI screens (Fixes JB#29417)

### DIFF
--- a/util.h
+++ b/util.h
@@ -91,7 +91,14 @@ private:
     bool swipeModeSet;
     bool swipeAllowed;
 
-    void scrollBackBuffer(QPointF now, QPointF last);
+    /**
+     * Scroll the back buffer on drag.
+     *
+     * @param now The current position
+     * @param last The last position (or start position)
+     * @return The new value for last (modified by any consumed offset)
+     **/
+    QPointF scrollBackBuffer(QPointF now, QPointF last);
     void doGesture(PanGesture gesture);
     void clearNotifications();
     void selectionHelper(QPointF scenePos);


### PR DESCRIPTION
The scrolling code was just scrolling at most one line at a time, and even when the touch point moved even just one pixel.

Fix that by using the font size as a scale factor (that's still not 100% correct, but it improves the situation, and the bias scales well with changing font size) and by actually accumulating not consumed offsets, so small moves (smaller than the font size) are not discarded, but actually accumulate.