### PR TITLE
Hardware keyboard improvements

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -28,7 +28,7 @@ PageStackWindow {
     focus: true
 
     Keys.onPressed: {
-        window.vkbKeypress(event.key,event.modifiers);
+        term.keyPress(event.key,event.modifiers);
     }
 
     property string windowTitle: util.currentWindowTitle();

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -28,7 +28,7 @@ PageStackWindow {
     focus: true
 
     Keys.onPressed: {
-        term.keyPress(event.key,event.modifiers);
+        term.keyPress(event.key,event.modifiers,event.text);
     }
 
     property string windowTitle: util.currentWindowTitle();

--- a/terminal.h
+++ b/terminal.h
@@ -79,7 +79,7 @@ public:
 
     QList<TermChar>& currentLine();
 
-    Q_INVOKABLE void keyPress(int key, int modifiers);
+    Q_INVOKABLE void keyPress(int key, int modifiers, const QString& text="");
     Q_INVOKABLE const QStringList printableLinesFromCursor(int lines);
     Q_INVOKABLE void putString(QString str, bool unEscape=false);
 


### PR DESCRIPTION
This fixes #54 along with other improvements to behavior of hardware keyboards:
- virtual/touch keyboard doesnt wake up on hardware keypress, for using hwkbd while vkb enabled 
- use event.text from Qt keyEvents, fixes capslock and russian (propably other too) text input
- modifiers (shift,alt,control) for editing/nav keys, notably alt-left/right
- insert key at all (also with modifiers)
- Function keys (with modifiers)
